### PR TITLE
Add customize options to set flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,28 @@ You can change the keybinding shortcuts from the default of `C-c ?` by
 customising the `seeing-is-believing-prefix` variable
 (`M-x set-variable <return> seeing-is-believing-prefix <return>`).
 
+You can also customize or set variables that affect how seeing-is-believing
+operates:
+
+- `seeing-is-believing-max-length` can be set to an integer that limits the
+  length of lines produced, source plus comments (default 1000).
+- `seeing-is-believing-max-results` can be set to an integer that limits the
+  number of results produced, when `seeing-is-believing` shows multiple results
+  per comment (default 10),
+- `seeing-is-believing-timout` can be set to a decimal number for the number of
+  seconds `seeing-is-believing` runs before it times out or to 0 for no timeout
+  (default 0), and
+- `seeing-is-believing-alignment` can be set to one of `'chunk`, `'file`, or
+  `'line'` to change the way `seeing-is-believing` aligns its comments, on a
+  chunk-by-chunk basis, across the whole file, or on a line-by-line basis,
+  effectively no alignment (default "chunk").
+
+```lisp
+(setq seeing-is-believing-max-length 150
+      seeing-is-believing-max-results 10
+      seeing-is-believing-timeout 10.5
+      seeing-is-believing-alignment 'file)
+```
 ## Licence ##
 
 Copyright 2015 John Cinnamond

--- a/README.md
+++ b/README.md
@@ -36,6 +36,30 @@ You can change the keybinding shortcuts from the default of `C-c ?` by
 customising the `seeing-is-believing-prefix` variable
 (`M-x set-variable <return> seeing-is-believing-prefix <return>`).
 
+You can also customize or set variables that affect how seeing-is-believing
+operates:
+
+- `seeing-is-believing-executable` can be set to the name of the program file
+  for the executable (default "seeing\_is\_believing")
+- `seeing-is-believing-max-length` can be set to an integer that limits the
+  length of lines produced, source plus comments (default 1000).
+- `seeing-is-believing-max-results` can be set to an integer that limits the
+  number of results produced, when `seeing-is-believing` shows multiple results
+  per comment (default 10),
+- `seeing-is-believing-timout` can be set to a decimal number for the number of
+  seconds `seeing-is-believing` runs before it times out or to 0 for no timeout
+  (default 0), and
+- `seeing-is-believing-alignment` can be set to one of `'chunk`, `'file`, or
+  `'line'` to change the way `seeing-is-believing` aligns its comments, on a
+  chunk-by-chunk basis, across the whole file, or on a line-by-line basis,
+  effectively no alignment (default "chunk").
+
+```lisp
+(setq seeing-is-believing-max-length 150
+      seeing-is-believing-max-results 10
+      seeing-is-believing-timeout 10.5
+      seeing-is-believing-alignment 'file)
+```
 ## Licence ##
 
 Copyright 2015 John Cinnamond

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can change the keybinding shortcuts from the default of `C-c ?` by
 customising the `seeing-is-believing-prefix` variable
 (`M-x set-variable <return> seeing-is-believing-prefix <return>`).
 
-You can also customize or set variables that affect how seeing-is-believing
+You can also customize or set variables that affect how `seeing-is-believing`
 operates:
 
 - `seeing-is-believing-executable` can be set to the name of the program file
@@ -50,9 +50,12 @@ operates:
   seconds `seeing-is-believing` runs before it times out or to 0 for no timeout
   (default 0), and
 - `seeing-is-believing-alignment` can be set to one of `'chunk`, `'file`, or
-  `'line'` to change the way `seeing-is-believing` aligns its comments, on a
+  `'line` to change the way `seeing-is-believing` aligns its comments, on a
   chunk-by-chunk basis, across the whole file, or on a line-by-line basis,
   effectively no alignment (default "chunk").
+
+Either use the customize interface to set these, or set them in your `init.el`
+file:
 
 ```lisp
 (setq seeing-is-believing-max-length 150
@@ -60,6 +63,7 @@ operates:
       seeing-is-believing-timeout 10.5
       seeing-is-believing-alignment 'file)
 ```
+
 ## Licence ##
 
 Copyright 2015 John Cinnamond

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can change the keybinding shortcuts from the default of `C-c ?` by
 customising the `seeing-is-believing-prefix` variable
 (`M-x set-variable <return> seeing-is-believing-prefix <return>`).
 
-You can also customize or set variables that affect how seeing-is-believing
+You can also customize or set variables that affect how `seeing-is-believing`
 operates:
 
 - `seeing-is-believing-executable` can be set to the name of the program file
@@ -50,16 +50,16 @@ operates:
   seconds `seeing-is-believing` runs before it times out or to 0 for no timeout
   (default 0), and
 - `seeing-is-believing-alignment` can be set to one of `'chunk`, `'file`, or
-  `'line'` to change the way `seeing-is-believing` aligns its comments, on a
+  `'line` to change the way `seeing-is-believing` aligns its comments, on a
   chunk-by-chunk basis, across the whole file, or on a line-by-line basis,
   effectively no alignment (default "chunk").
 
-```lisp
-(setq seeing-is-believing-max-length 150
-      seeing-is-believing-max-results 10
-      seeing-is-believing-timeout 10.5
-      seeing-is-believing-alignment 'file)
-```
+Either use the customize interface to set these, or set them in your `init.el`
+file:
+
+```lisp (setq seeing-is-believing-max-length 150
+seeing-is-believing-max-results 10 seeing-is-believing-timeout 10.5
+seeing-is-believing-alignment 'file) ```
 ## Licence ##
 
 Copyright 2015 John Cinnamond

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ operates:
 - `seeing-is-believing-max-results` can be set to an integer that limits the
   number of results produced, when `seeing-is-believing` shows multiple results
   per comment (default 10),
-- `seeing-is-believing-timout` can be set to a decimal number for the number of
+- `seeing-is-believing-timeout` can be set to a decimal number for the number of
   seconds `seeing-is-believing` runs before it times out or to 0 for no timeout
   (default 0), and
 - `seeing-is-believing-alignment` can be set to one of `'chunk`, `'file`, or
   `'line` to change the way `seeing-is-believing` aligns its comments, on a
   chunk-by-chunk basis, across the whole file, or on a line-by-line basis,
-  effectively no alignment (default "chunk").
+  effectively no alignment (default `'chunk`).
 
 Either use the customize interface to set these, or set them in your `init.el`
 file:

--- a/seeing-is-believing.el
+++ b/seeing-is-believing.el
@@ -3,7 +3,7 @@
 ;; Copyright 2015 John Cinnamond
 
 ;; Author: John Cinnamond
-;; Version: 1.1.0
+;; Version: 1.2.0
 
 ;;; Commentary:
 ;;

--- a/seeing-is-believing.el
+++ b/seeing-is-believing.el
@@ -50,6 +50,33 @@
   :type 'string
   :group 'seeing-is-believing)
 
+(defcustom seeing-is-believing-max-length
+  1000
+  "Maximum length of output line, source plus comment."
+  :type 'integer
+  :group 'seeing-is-believing)
+
+(defcustom seeing-is-believing-max-results
+  10
+  "Maximum number of separate results per comment line."
+  :type 'integer
+  :group 'seeing-is-believing)
+
+(defcustom seeing-is-believing-timeout
+  0
+  "Number of seconds before timing out; 0 means no timeout."
+  :type 'number
+  :group 'seeing-is-believing)
+
+(defcustom seeing-is-believing-alignment
+  'chunk
+  "How to align the result comments."
+  :type '(choice
+          (const :tag "each chunk of code is at the same alignment" chunk)
+          (const :tag "the entire file is at the same alignment" file)
+          (const :tag "each line is at its own alignment" line))
+  :group 'seeing-is-believing)
+
 (defcustom seeing-is-believing-prefix
   "C-c ?"
   "The prefix for key bindings for running seeing-is-believing commands."
@@ -73,7 +100,9 @@ Optional FLAGS are passed to the seeing_is_believing command."
   (let ((beg (if (region-active-p) (region-beginning) (point-min)))
         (end (if (region-active-p) (region-end) (point-max)))
         (origin (point)))
-    (shell-command-on-region beg end (concat seeing-is-believing-executable " " flags) nil 'replace)
+    (shell-command-on-region beg end
+                             (concat seeing-is-believing-executable " "
+                                     flags (seeing-is-believing~flags)) nil 'replace)
     (goto-char origin)))
 
 (defun seeing-is-believing-run-as-xmpfilter ()
@@ -92,6 +121,13 @@ Optional FLAGS are passed to the seeing_is_believing command."
   (save-excursion
     (end-of-line)
     (insert " # =>")))
+
+(defun seeing-is-believing~flags ()
+  "Construct flags reflecting custom options"
+  (concat " -d " (format "%d" seeing-is-believing-max-length)
+          " -n " (format "%d" seeing-is-believing-max-results)
+          " -t " (format "%f" seeing-is-believing-timeout)
+          " -s " (format "%s" seeing-is-believing-alignment)))
 
 (define-minor-mode seeing-is-believing
   "Toggle seeing-is-believing minor mode.


### PR DESCRIPTION
Allowing user to set limits on line size, number or results per line,
timeout, and alignment type.  Perhaps the timeout should be set to something
like 5 seconds in case the user enters long execution inadvertently.